### PR TITLE
User story 3 - Error message for Application

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -23,7 +23,7 @@ class ApplicationsController < ApplicationController
     if application.save
       redirect_to "/applications/#{application.id}"
     else 
-      redirect_to "/applications/#{application.id}/new"
+      redirect_to "/applications/new"
       flash[:alert] = "Error: #{error_message(application.errors)}"
     end 
   end

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -19,8 +19,12 @@ class ApplicationsController < ApplicationController
     description: params[:description],
     status: "In Progress"
     })
-    application.save
-
-    redirect_to "/applications/#{application.id}"
+    
+    if application.save
+      redirect_to "/applications/#{application.id}"
+    else 
+      redirect_to "/applications/#{application.id}/new"
+      flash[:alert] = "Error: #{error_message(application.errors)}"
+    end 
   end
 end

--- a/spec/features/applications/new_spec.rb
+++ b/spec/features/applications/new_spec.rb
@@ -29,11 +29,11 @@ RSpec.describe "applications#new" do
       fill_in(:state, with: "BA")
       fill_in(:zipcode, with: "123456")
       fill_in(:description, with: "My name's rappin Jeff and I'm here to say")
-
+      
       click_button("Submit")
-
+      
       application = Application.last
-
+      
       expect(current_path).to eq("/applications/#{application.id}")
       expect(page).to have_content("Jeff")
       expect(page).to have_content("123 Fake St")
@@ -41,6 +41,25 @@ RSpec.describe "applications#new" do
       expect(page).to have_content("BA")
       expect(page).to have_content("123456")
       expect(page).to have_content("My name's rappin Jeff and I'm here to say")
+    end
+  end
+  
+  describe "incomplete application" do 
+    it "renders an error message when any field in the new application is not filled out" do 
+      visit "/applications/new"
+
+      fill_in(:name, with: "")
+      fill_in(:street_address, with: "123 Fake St")
+      fill_in(:city, with: "Coolsville")
+      fill_in(:state, with: "BA")
+      fill_in(:zipcode, with: "123456")
+      fill_in(:description, with: "My name's rappin Jeff and I'm here to say")
+
+      click_button("Submit")
+
+      expect(current_path).to eq("/applications/new")
+      expect(page).to have_content("Error: Name can't be blank")
+
     end
   end
 end


### PR DESCRIPTION
Database/Migrations: None

Routes: None

Models: None

Controllers: Added conditional statement in #create method to account for not filling in certain fields. Reutilized the error messaging code from pets_controller. Messed around with a custom message but decided to leave it with the generic one. 

Views:

Testing:
	Models:

	Features: Added test in the applications/new_spec.rb  to test that we receive and error message when we don't fill in a certain field. 

Considerations(Extra notes, refactors, etc.):

We could have a more customized or generic error message. However, the current set up gives you that specifically says which field is not filled out which is kinda nice. 
