### PR TITLE
Refactor

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -36,11 +36,16 @@ class ApplicationsController < ApplicationController
 
   def update
     application = Application.find(params[:id])
-    application.update({ 
-      adoption_reason: params[:adoption_reason],
-      status: "Pending"
-    })
-    
-    redirect_to "/applications/#{application.id}"
+    if params[:adoption_reason].empty?
+      redirect_to "/applications/#{application.id}"
+      flash[:alert] = "Error: Adoption reason field cannot be empty"
+    else
+      application.update({ 
+        adoption_reason: params[:adoption_reason],
+        status: "Pending"
+      })
+      
+      redirect_to "/applications/#{application.id}"
+    end
   end
 end

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -7,13 +7,13 @@
   <h3>Status: <%= @application.status %></h3>
 </section>
 
-<section id="pets_applied_for">
   <h3>Pets Applied For</h3>
   <% @application.pets.each do |pet| %>
+<section id="pets_applied_for-<%= pet.id%>">
   <%= link_to "#{pet.name}", "/pets/#{pet.id}" %>
       <h3><%= pet.name %> Adoption Approval Status: <h3 style="color:red"><%= @application.individual_pet_status(pet) %> </h3>
-  <% end  %>
 </section>
+  <% end  %>
 
 <% if @application.status == "In Progress" %>
   <h3>Add a pet this application</h3>

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -153,5 +153,24 @@ RSpec.describe "applications#show" do
         expect(page).to have_content("Pending")
       end
     end
+
+    it "sends an error message if the adoption reason is left blank" do
+      visit "/applications/#{@application_1.id}"
+
+      within("#applicant_info-#{@application_1.id}") do 
+        expect(page).to have_content("In Progress")
+      end
+
+      fill_in(:search, with: "Mr. Pirate")
+      
+      click_button("Search")
+      click_button("Adopt this Pet")
+      
+      fill_in(:adoption_reason, with: "")
+      click_button("Submit")
+
+      expect(current_path).to eq("/applications/#{@application_1.id}")
+      expect(page).to have_content("Error: Adoption reason field cannot be empty")
+    end
   end
 end

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe "applications#show" do
 
       expect(@application_1.pets).to eq([@pet_1])
 
-      within("#pets_applied_for") do 
+      within("#pets_applied_for-#{@pet_1.id}") do 
         expect(page).to have_content(@pet_1.name)
       end
     end


### PR DESCRIPTION
Database/Migrations: 

Routes:

Models:

Controllers:
Added a flash message for if the adoption reason field is left blank to say " Error: Adoption reason field cannot be empty". 

Views:
Moved the section block around and added the interpolation of the pet.id in to the section id. 

Testing:
	Models:

	Features:
Tested the functionality of the change to the section id in the show view as well as the functionality of the flash error message if the adoption reason is left blank. 

Considerations(Extra notes, refactors, etc.):
